### PR TITLE
Redirect users without translator/developer roles to login/projects list

### DIFF
--- a/app/models/project.coffee
+++ b/app/models/project.coffee
@@ -12,7 +12,8 @@ App.Project = Ember.Object.extend
   
   userRoles: (->
     user = @get('currentUser')
-    userRoles = @get('roles').filter (role) -> role.name is user.name
+    roles = @get('roles') or []
+    userRoles = roles.filter (role) -> role.name is user.name
     userRoles[0]?.roles or []
   ).property('roles')
   

--- a/app/routes/project.coffee
+++ b/app/routes/project.coffee
@@ -9,8 +9,9 @@ App.ProjectRoute = AuthenticatedRoute.extend
       @loadingIndicator = new Spinner().spin()
       document.querySelector('#app').appendChild @loadingIndicator.el
   
-  afterModel: ->
+  afterModel: (project) ->
     @loadingIndicator.stop()
+    @transitionTo('login') unless project.get('isAccessible')
   
   model: (params) ->
     promises = Ember.RSVP.hash


### PR DESCRIPTION
This should solve the recent problems we've been having on Penguins. This ensures that anyone who tries to access a project's translation screen has credentials to be able to submit translations. Otherwise it redirects you to the login/projects list.