### PR TITLE
Fix roles. I think.

### DIFF
--- a/app/models/project.coffee
+++ b/app/models/project.coffee
@@ -12,9 +12,8 @@ App.Project = Ember.Object.extend
   
   userRoles: (->
     user = @get('currentUser')
-    roles = @get('roles') or []
-    userRoles = roles.filter (role) -> role.name is user.name
-    userRoles[0]?.roles or []
+    userRoles = user?.talk?.roles or {}
+    userRolesForProject = userRoles[@get('id')] or []
   ).property('roles')
   
   isTranslator: (->

--- a/app/routes/project.coffee
+++ b/app/routes/project.coffee
@@ -11,11 +11,11 @@ App.ProjectRoute = AuthenticatedRoute.extend
   
   afterModel: (project) ->
     @loadingIndicator.stop()
-    @transitionTo('login') unless project.get('isAccessible')
+    @transitionTo('projects') unless project.get('isAccessible')
   
   model: (params) ->
     promises = Ember.RSVP.hash
-      project: zooniverse.api.get("/projects/list/#{ params.name }", with_roles: true)
+      project: zooniverse.api.get("/projects/#{ params.name }")
       translation: zooniverse.api.get("/projects/#{ params.name }/translations")
     
     promises.then (resolved) ->


### PR DESCRIPTION
I believe this actually fixes all this role stuff.

It properly looks at the user object for the appropriate role on the current project. It also uses the `/project/:project_name` route, so it still has access to deploy info (as `/projects/list/:project_name` returns an abbreviated project object.